### PR TITLE
Specify the -process CLI option

### DIFF
--- a/plugin/javaScriptLint.vim
+++ b/plugin/javaScriptLint.vim
@@ -39,6 +39,7 @@ if !exists("jslint_command_options")
   if filereadable(jslint_config_file)
     let jslint_command_options = g:jslint_command_options . " --conf " . g:jslint_config_file
   endif
+  let jslint_command_options = g:jslint_command_options . " -process"
 endif
 
 if !exists("jslint_highlight_color")


### PR DESCRIPTION
Adds the -process CLI option to allow for specifying the file to be
processed. I'm not sure how it would ever work without that.
